### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/venv/Lib/site-packages/scipy/fftpack/realtransforms.py
+++ b/venv/Lib/site-packages/scipy/fftpack/realtransforms.py
@@ -354,7 +354,7 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     .. [1] 'A Fast Cosine Transform in One and Two Dimensions', by J.
            Makhoul, `IEEE Transactions on acoustics, speech and signal
            processing` vol. 28(1), pp. 27-34,
-           http://dx.doi.org/10.1109/TASSP.1980.1163351 (1980).
+           https://doi.org/10.1109/TASSP.1980.1163351 (1980).
     .. [2] Wikipedia, "Discrete cosine transform",
            http://en.wikipedia.org/wiki/Discrete_cosine_transform
 

--- a/venv/Lib/site-packages/scipy/linalg/interpolative.py
+++ b/venv/Lib/site-packages/scipy/linalg/interpolative.py
@@ -123,22 +123,22 @@ We advise the user to consult also the `documentation for the ID package
 
 .. [2] H. Cheng, Z. Gimbutas, P.G. Martinsson, V. Rokhlin. "On the
     compression of low rank matrices." *SIAM J. Sci. Comput.* 26 (4): 1389--1404,
-    2005. `doi:10.1137/030602678 <http://dx.doi.org/10.1137/030602678>`_.
+    2005. `doi:10.1137/030602678 <https://doi.org/10.1137/030602678>`_.
 
 .. [3] E. Liberty, F. Woolfe, P.G. Martinsson, V. Rokhlin, M.
     Tygert. "Randomized algorithms for the low-rank approximation of matrices."
     *Proc. Natl. Acad. Sci. U.S.A.* 104 (51): 20167--20172, 2007.
-    `doi:10.1073/pnas.0709640104 <http://dx.doi.org/10.1073/pnas.0709640104>`_.
+    `doi:10.1073/pnas.0709640104 <https://doi.org/10.1073/pnas.0709640104>`_.
 
 .. [4] P.G. Martinsson, V. Rokhlin, M. Tygert. "A randomized
     algorithm for the decomposition of matrices." *Appl. Comput. Harmon. Anal.* 30
     (1): 47--68,  2011. `doi:10.1016/j.acha.2010.02.003
-    <http://dx.doi.org/10.1016/j.acha.2010.02.003>`_.
+    <https://doi.org/10.1016/j.acha.2010.02.003>`_.
 
 .. [5] F. Woolfe, E. Liberty, V. Rokhlin, M. Tygert. "A fast
     randomized algorithm for the approximation of matrices." *Appl. Comput.
     Harmon. Anal.* 25 (3): 335--366, 2008. `doi:10.1016/j.acha.2007.12.002
-    <http://dx.doi.org/10.1016/j.acha.2007.12.002>`_.
+    <https://doi.org/10.1016/j.acha.2007.12.002>`_.
 
 
 Tutorial

--- a/venv/Lib/site-packages/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/venv/Lib/site-packages/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -254,7 +254,7 @@ def lobpcg(A, X,
            Toward the Optimal Preconditioned Eigensolver: Locally Optimal
            Block Preconditioned Conjugate Gradient Method.
            SIAM Journal on Scientific Computing 23, no. 2,
-           pp. 517-541. http://dx.doi.org/10.1137/S1064827500366124
+           pp. 517-541. https://doi.org/10.1137/S1064827500366124
 
     .. [2] A. V. Knyazev, I. Lashuk, M. E. Argentati, and E. Ovchinnikov (2007),
            Block Locally Optimal Preconditioned Eigenvalue Xolvers (BLOPEX)


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

Cheers :-)